### PR TITLE
A few edits, comments below.

### DIFF
--- a/womp-9999.md
+++ b/womp-9999.md
@@ -39,26 +39,26 @@ A change or introduction of a process
 
 ## WPP.Open steering council
 
-“Steering Council” or “Council” refers to a group of people elected to manage the choices driven by the WOMPs. The election process and the membership is defined and published in WOMP 0002. There are always 5 Council members.
+“Steering Council” or “Council” refers to a group of people elected to manage the choices driven by the WOMPs. The election process and the membership is defined and published in WOMP 0002. 
 
 ## Core developers
 
 “Core developers” refers to product and technology leaders responsible for:
-Electing the “Steering Council” members
-Development and sponsorship of WOMPs
-Implementation of WOMP mandates choices and processes
+* Electing the “Steering Council” members
+* Development and sponsorship of WOMPs
+* Implementation of WOMP mandates, choices, and processes
 Membership is granted by invite from the Council.
 
 ## WOMP editors
 
-Core developers will invite “WOMP editors” who usually will be members of their teams. The WOMP editors have the ability and rights to edit and maintain WOMPs to which they have been invited. Editors are not considered to be automatically granted the ‘Core’ status.
+Core developers will invite “WOMP editors” who will usually be members of their teams. The WOMP editors have the ability and rights to edit and maintain WOMPs to which they have been invited. Editors are not automatically added to the "Core Developers".
 
 ## WOMP lifecycle
 
 The WOMP process starts with a new idea for a WPP.Open standard, process or information. Each proposal must have a focused scope on a single idea.
 Each WOMP needs a Champion who is responsible for preparing, maintaining, socializing, and driving the WOMP through the process. It is a good practice to socialize the idea before submitting the WOMP through appropriate channels. These channels will be defined in WOMP0003. This process is necessary to check if the idea is WOMPable and if it will get enough traction to get incorporated. At this stage the WOMP is in a Draft format.
 
-WOMPs are stored in a repository. Each new WOMP starts its life on its own branch and is numbered as WOMP9999. A pull request is raised. Steering council will regularly review these PRs. If the draft is found to be satisfactory it will be assigned a WOMP number and its status changed to ‘Proposed’. This starts a review process driven by the Champion. The review process needs to give all the Core members enough time to have a discussion about the proposal and make appropriate amendments. The amendments are implemented by the Champion.
+WOMPs are stored in a repository. Each new WOMP starts its life on its own branch and is numbered as WOMP9999. A pull request is raised. Steering council will regularly review these PRs. If the draft is found to be satisfactory it will be assigned a WOMP number and its status changed to ‘Proposed’. This starts a review process driven by the Champion. The review process needs to give all the Core members enough time to have a discussion the proposal and make appropriate amendments. The amendments are implemented by the Champion.
 
 After the consultation period, WOMP is voted in by a majority of the Council and moved to a ‘Final’ state.
 


### PR DESCRIPTION
Overall a great start!
I think I prefer a more structured definition of the Body myself, but am not opposed to leaving it loose.
The "Core developers" section feels a bit recursive (they elect the Council which in turn appoints people to the core, etc.) but will wait for WOMP0002 to see how that whole process works (assuming the "Core developers" will be better defined there as well).